### PR TITLE
Adding option to disable local search

### DIFF
--- a/lib/src/mention_view.dart
+++ b/lib/src/mention_view.dart
@@ -51,7 +51,13 @@ class FlutterMentions extends StatefulWidget {
     this.appendSpaceOnAdd = true,
     this.hideSuggestionList = false,
     this.onSuggestionVisibleChanged,
+    this.smartDashesType,
+    this.smartQuotesType,
   }) : super(key: key);
+
+  final SmartDashesType? smartDashesType;
+
+  final SmartQuotesType? smartQuotesType;
 
   final bool hideSuggestionList;
 
@@ -198,17 +204,8 @@ class FlutterMentions extends StatefulWidget {
   /// {@macro flutter.widgets.editableText.cursorRadius}
   final Radius? cursorRadius;
 
-  /// The color to use when painting the cursor.
-  ///
-  /// Defaults to [ThemeData.cursorColor] or [CupertinoTheme.primaryColor]
-  /// depending on [ThemeData.platform] .
   final Color? cursorColor;
 
-  /// The appearance of the keyboard.
-  ///
-  /// This setting is only honored on iOS devices.
-  ///
-  /// If unset, defaults to the brightness of [ThemeData.primaryColorBrightness].
   final Brightness? keyboardAppearance;
 
   /// {@macro flutter.widgets.editableText.scrollPadding}
@@ -303,8 +300,7 @@ class FlutterMentionsState extends State<FlutterMentions> {
       _selectedMention = null;
     });
 
-    final _list = widget.mentions
-        .firstWhere((element) => selectedMention.str.contains(element.trigger));
+    final _list = widget.mentions.firstWhere((element) => selectedMention.str.contains(element.trigger));
 
     // find the text by range and replace with the new value.
     controller!.text = controller!.value.text.replaceRange(
@@ -316,11 +312,9 @@ class FlutterMentionsState extends State<FlutterMentions> {
     if (widget.onMentionAdd != null) widget.onMentionAdd!(value);
 
     // Move the cursor to next position after the new mentioned item.
-    var nextCursorPosition =
-        selectedMention.start + 1 + value['display']?.length as int? ?? 0;
+    var nextCursorPosition = selectedMention.start + 1 + value['display']?.length as int? ?? 0;
     if (widget.appendSpaceOnAdd) nextCursorPosition++;
-    controller!.selection =
-        TextSelection.fromPosition(TextPosition(offset: nextCursorPosition));
+    controller!.selection = TextSelection.fromPosition(TextPosition(offset: nextCursorPosition));
   }
 
   void suggestionListerner() {
@@ -333,8 +327,7 @@ class FlutterMentionsState extends State<FlutterMentions> {
 
       // split on each word and generate a list with start & end position of each word.
       controller!.value.text.split(RegExp(r'(\s)')).forEach((element) {
-        lengthMap.add(
-            LengthMap(str: element, start: _pos, end: _pos + element.length));
+        lengthMap.add(LengthMap(str: element, start: _pos, end: _pos + element.length));
 
         _pos = _pos + element.length + 1;
       });
@@ -342,8 +335,7 @@ class FlutterMentionsState extends State<FlutterMentions> {
       final val = lengthMap.indexWhere((element) {
         _pattern = widget.mentions.map((e) => e.trigger).join('|');
 
-        return element.end == cursorPos &&
-            element.str.toLowerCase().contains(RegExp(_pattern));
+        return element.end == cursorPos && element.str.toLowerCase().contains(RegExp(_pattern));
       });
 
       showSuggestions.value = val != -1;
@@ -411,18 +403,15 @@ class FlutterMentionsState extends State<FlutterMentions> {
   Widget build(BuildContext context) {
     // Filter the list based on the selection
     final list = _selectedMention != null
-        ? widget.mentions.firstWhere(
-            (element) => _selectedMention!.str.contains(element.trigger))
+        ? widget.mentions.firstWhere((element) => _selectedMention!.str.contains(element.trigger))
         : widget.mentions[0];
 
     return Container(
       child: PortalEntry(
-        portalAnchor: widget.suggestionPosition == SuggestionPosition.Bottom
-            ? Alignment.topCenter
-            : Alignment.bottomCenter,
-        childAnchor: widget.suggestionPosition == SuggestionPosition.Bottom
-            ? Alignment.bottomCenter
-            : Alignment.topCenter,
+        portalAnchor:
+            widget.suggestionPosition == SuggestionPosition.Bottom ? Alignment.topCenter : Alignment.bottomCenter,
+        childAnchor:
+            widget.suggestionPosition == SuggestionPosition.Bottom ? Alignment.bottomCenter : Alignment.topCenter,
         portal: ValueListenableBuilder(
           valueListenable: showSuggestions,
           builder: (BuildContext context, bool show, Widget? child) {
@@ -435,9 +424,7 @@ class FlutterMentionsState extends State<FlutterMentions> {
                         ? list.data
                         : list.data.where((element) {
                             final ele = element['display'].toLowerCase();
-                            final str = _selectedMention!.str
-                                .toLowerCase()
-                                .replaceAll(RegExp(_pattern), '');
+                            final str = _selectedMention!.str.toLowerCase().replaceAll(RegExp(_pattern), '');
 
                             return ele == str ? false : ele.contains(str);
                           }).toList(),
@@ -487,6 +474,8 @@ class FlutterMentionsState extends State<FlutterMentions> {
                 scrollPadding: widget.scrollPadding,
                 scrollPhysics: widget.scrollPhysics,
                 controller: controller,
+                smartDashesType: widget.smartDashesType,
+                smartQuotesType: widget.smartQuotesType,
               ),
             ),
             ...widget.trailing,

--- a/lib/src/mention_view.dart
+++ b/lib/src/mention_view.dart
@@ -5,6 +5,7 @@ class FlutterMentions extends StatefulWidget {
     required this.mentions,
     Key? key,
     this.defaultText,
+    this.disableLocalSearch = false,
     this.suggestionPosition = SuggestionPosition.Bottom,
     this.suggestionListHeight = 300.0,
     this.onMarkupChanged,
@@ -53,6 +54,9 @@ class FlutterMentions extends StatefulWidget {
   }) : super(key: key);
 
   final bool hideSuggestionList;
+
+  /// Disable local search/filter.
+  final bool disableLocalSearch;
 
   /// default text for the Mention Input.
   final String? defaultText;
@@ -427,14 +431,16 @@ class FlutterMentionsState extends State<FlutterMentions> {
                     suggestionListHeight: widget.suggestionListHeight,
                     suggestionBuilder: list.suggestionBuilder,
                     suggestionListDecoration: widget.suggestionListDecoration,
-                    data: list.data.where((element) {
-                      final ele = element['display'].toLowerCase();
-                      final str = _selectedMention!.str
-                          .toLowerCase()
-                          .replaceAll(RegExp(_pattern), '');
+                    data: widget.disableLocalSearch
+                        ? list.data
+                        : list.data.where((element) {
+                            final ele = element['display'].toLowerCase();
+                            final str = _selectedMention!.str
+                                .toLowerCase()
+                                .replaceAll(RegExp(_pattern), '');
 
-                      return ele == str ? false : ele.contains(str);
-                    }).toList(),
+                            return ele == str ? false : ele.contains(str);
+                          }).toList(),
                     onTap: (value) {
                       addMention(value, list);
                       showSuggestions.value = false;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,14 +21,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -42,14 +42,14 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -73,21 +73,28 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.4"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -99,7 +106,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
@@ -134,21 +141,14 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
+    version: "0.4.9"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.17.0-0 <3.0.0"
   flutter: ">=1.21.0"


### PR DESCRIPTION
I ran into the issue where I was searching/filtering the mentions data via remote http calls, and then updating state with the newly filtered data. However, the library then also filters the data using some string matching. The issue is that we allow searching by more than just the display value, and so results coming from our remote search wouldn't show up in the list because the library filtered them out.

This adds a 'disableLocalSearch' option that skips the local searching/filtering if it is true. It defaults to false for backwards compatibility.