### PR TITLE
Fix/make max lines nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [2.0.2] 15 Oct 2021
+- `FlutterMentions.maxLines` is now nullable to be compatible with (TextField.maxLines)[https://api.flutter.dev/flutter/cupertino/CupertinoTextField/maxLines.html]
+
 ## [2.0.1] - 24 May 2021
 
 - Added support for Flutter 2.2.0

--- a/lib/src/mention_view.dart
+++ b/lib/src/mention_view.dart
@@ -142,7 +142,7 @@ class FlutterMentions extends StatefulWidget {
   final bool enableSuggestions;
 
   /// {@macro flutter.widgets.editableText.maxLines}
-  final int maxLines;
+  final int? maxLines;
 
   /// {@macro flutter.widgets.editableText.minLines}
   final int? minLines;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_mentions
 description: A simple flutter input widget to add @ mentions functionality to your app.
-version: 2.0.1
+version: 2.0.2
 homepage: https://github.com/fayeed/flutter_mentions
 
 environment:


### PR DESCRIPTION
Making maxLines nullable to be compatible with https://api.flutter.dev/flutter/cupertino/CupertinoTextField/maxLines.html
- minLines and maxLines must be null when expands is true